### PR TITLE
[#3] MyBatis 연동하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+**/application.properties

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ build/
 ### VS Code ###
 .vscode/
 
-**/application.properties
+application.properties

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -39,6 +40,32 @@
                     <artifactId>junit-vintage-engine</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+            <version>2.3.1.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.20</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mybatis</groupId>
+            <artifactId>mybatis</artifactId>
+            <version>3.5.5</version>
+        </dependency>
+
+
+
+        <dependency>
+            <groupId>org.mybatis</groupId>
+            <artifactId>mybatis-spring</artifactId>
+            <version>2.0.5</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mybatis.spring.boot</groupId>
+            <artifactId>mybatis-spring-boot-starter</artifactId>
+            <version>2.1.3</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
@@ -54,19 +60,6 @@
             <version>8.0.20</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.mybatis</groupId>
-            <artifactId>mybatis</artifactId>
-            <version>3.5.5</version>
-        </dependency>
-
-
-
-        <dependency>
-            <groupId>org.mybatis</groupId>
-            <artifactId>mybatis-spring</artifactId>
-            <version>2.0.5</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/flab/makedel/config/DatabaseConfig.java
+++ b/src/main/java/com/flab/makedel/config/DatabaseConfig.java
@@ -10,9 +10,21 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import javax.sql.DataSource;
+/*
+        @Configuration
+        스프링이 빈 팩토리를 위해 별도의 환경설정 정보를 담당하는 클래스라고 인식할 수 있도록 @configuration 애노테이션을 추가합니다.
+        이 클래스 안에서는 @bean 애노테이션을 통해 메소드들을 빈으로 추가해줍니다.
+        @SpringBootAplication 애노테이션에 메타애노테이션으로 @componentscan 이 있습니다.
+        이 컴퍼넌트 스캔은 스프링부트어플리케이션 애노테이션을 베이스패키지로 삼아 @component 애노테이션을 찾아서 애플리케이션 컨텍스트에 빈으로 추가합니다.
+        @configuration 애노테이션에 메타애노테이션으로 @component가 있으므로 컴퍼넌트스캔이 @configuration을 빈으로 추가시킵니다.
 
-@Configuration //@Configuration을 통해 이 클래스는 Spring의 어노테이션 기반 환경 구성을 돕는다.
-@MapperScan(basePackages = "com.flab.makedel.mapper") //@MapperScan을 통해 Mapper Interface를 스프링 빈으로 주입받아 DB에 접근한다.
+        @MapperScan
+        베이스패키지라는 이름으로 Scan할 범위를 지정하고
+        그 베이스패키지부터 하위패키지 까지 Mapper Interface 가 있는지 모두 스캔하여 모든 Mapper를 등록합니다.
+        이 스캔 기능은 마이바티스 스프링 연동모듈이 자동스캔 해주는 것입니다.
+*/
+@Configuration
+@MapperScan(basePackages = "com.flab.makedel.mapper")
 public class DatabaseConfig {
 
     @Autowired

--- a/src/main/java/com/flab/makedel/config/DatabaseConfig.java
+++ b/src/main/java/com/flab/makedel/config/DatabaseConfig.java
@@ -1,0 +1,34 @@
+package com.flab.makedel.config;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+@MapperScan(basePackages = "com.flab.makedel.mapper")
+public class DatabaseConfig {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Bean
+    public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
+        SqlSessionFactoryBean sqlSessionFactoryBean = new SqlSessionFactoryBean();
+        sqlSessionFactoryBean.setDataSource(dataSource);
+
+        sqlSessionFactoryBean.setMapperLocations(applicationContext.getResources("classpath:/mapper/**/*.xml"));
+        return sqlSessionFactoryBean.getObject();
+    }
+
+    @Bean
+    public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
+        return new SqlSessionTemplate(sqlSessionFactory);
+    }
+}

--- a/src/main/java/com/flab/makedel/config/DatabaseConfig.java
+++ b/src/main/java/com/flab/makedel/config/DatabaseConfig.java
@@ -11,8 +11,8 @@ import org.springframework.context.annotation.Configuration;
 
 import javax.sql.DataSource;
 
-@Configuration
-@MapperScan(basePackages = "com.flab.makedel.mapper")
+@Configuration //@Configuration을 통해 이 클래스는 Spring의 어노테이션 기반 환경 구성을 돕는다.
+@MapperScan(basePackages = "com.flab.makedel.mapper") //@MapperScan을 통해 Mapper Interface를 스프링 빈으로 주입받아 DB에 접근한다.
 public class DatabaseConfig {
 
     @Autowired

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-
+spring.datasource.drive-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/makedelivery?useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC
+spring.datasource.username=root
+spring.datasource.password=tkfkd11!!

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,0 @@
-spring.datasource.drive-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/makedelivery?useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=tkfkd11!!


### PR DESCRIPTION
- SqlSessionFactoryBuilder

는 개발자들을 위한 ,단순히 가독성을 좋은 소스코드를 작성하기위한

객체이다.

이 객체는 서버를 최초 1회 실행시에 SqlSessionFactory를 생성하는데 한번 쓰이고

사라지는 객체이다.

- SqlSession

SqlSession이란 RDB에 인증을 거친 논리적인 연결 상태를 말하는 것이다

한번의 db 요청하려면 SqlSession를 사용해야한다.

Session이란 인스턴스안에 있는 논리적인 실체로 현재 유저의 로그인 상태를 말한다.

하나의 SqlSession을 만들기 위해서는 jdbc프로그래밍에서 필요한것처럼 기본적으로

1. Url

2. Id

3. password

3개의 정보가 필요하고 그 이외에도 Mybatis에서는 캐싱정책의 사용유무, 지연 로딩 등등 많은 설정 정보들이 존재한다.

이러한 정보들을 SqlSession을 생성할때마다 전부 다시 정의하는 것은 매우 힘들다.

그렇기 때문에 이러한 설정값들을 한곳에 모아놓고 그 모아놓은 곳에서 객체를 가져오는 것이 효율적인데

이것이 SqlSessionFactory 이다.

SqlSessionFactory를 만들기위해서는 엄청 많은 정보들을 넣어줘야하는데 (id url AliasesPackage.....) 이 값들을  인스턴스를 

사용해서 new SqlSessionFactory() 이렇게 만드는 거는 올바르지 않을 수 있다. 

왜냐면 생성자 인자가 많은 경우에는 Constructor 방식은 가독성이 매우 떨어진다

그렇기에 이런경우에는 디자인패턴중에서  BuilderPattern을 사용하는데

이것이 SqlSessionFactoryBuilder이다.

출처: https://kimsoungryoul.tistory.com/43